### PR TITLE
Support ° (Unicode U+00B0) as a valid designator for degrees when parsing latitude/longitude

### DIFF
--- a/unitility-core/src/main/java/com/synerset/unitility/unitsystem/util/ParsingHelpers.java
+++ b/unitility-core/src/main/java/com/synerset/unitility/unitsystem/util/ParsingHelpers.java
@@ -74,7 +74,7 @@ public class ParsingHelpers {
             throw new UnitSystemArgumentException("Geo parser: Invalid input. Argument cannot be null or blank.");
         }
 
-        String[] parts = dmsFormat.split("[o'\"nsew]");
+        String[] parts = dmsFormat.split("[o°'\"nsew]");
 
         if (parts.length == 0) {
             throw new UnitSystemArgumentException("Geo DMS parser: Input string could not be parsed: input = "


### PR DESCRIPTION
Additional character to the splitting regex in `ParsingHelpers.extractDegreesToDMSFormat()` to support ° [(Unicode U+00B0)](https://en.wikipedia.org/wiki/Degree_symbol) as a valid designator for degrees when parsing latitude/longitude