### PR TITLE
Update ValueFormatter.java for different locale decimal separators.

### DIFF
--- a/unitility-core/src/main/java/com/synerset/unitility/unitsystem/util/ValueFormatter.java
+++ b/unitility-core/src/main/java/com/synerset/unitility/unitsystem/util/ValueFormatter.java
@@ -2,10 +2,12 @@ package com.synerset.unitility.unitsystem.util;
 
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 
 /**
  * The ValueFormatter class provides utility methods for formatting double values with a specified number of
  * relevant digits and decimal places.
+ * Set decimal '.' and grouping ',' separators of 'format()' for float numbers.(','  is used for decimal locale separators in USA/TR )
  */
 public class ValueFormatter {
 
@@ -46,7 +48,12 @@ public class ValueFormatter {
         if (numDecimalPlaces > 0) {
             formatString = "#." + "#".repeat(numDecimalPlaces);
         }
-        DecimalFormat decimalFormat = new DecimalFormat(formatString);
+        // Set locale decimal and grouping separators.
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols();
+        symbols.setDecimalSeparator('.');
+        symbols.setGroupingSeparator(',');
+        
+        DecimalFormat decimalFormat = new DecimalFormat(formatString, symbols);
         decimalFormat.setRoundingMode(RoundingMode.HALF_EVEN);
         return decimalFormat.format(value);
     }


### PR DESCRIPTION
# Pull Request
## Description

Set decimal '.' and grouping ',' separators of 'format ()' for float numbers. (',' is used for decimal locale separators in USA/TR)

## Summary of Changes

- ValueFormatterTest.java 
        Arguments.of(10.1234, 3, "10.123")
 
        DecimalFormatSymbols symbols = new DecimalFormatSymbols();
        symbols.setDecimalSeparator('.');  symbols.setGroupingSeparator(',');
         DecimalFormat decimalFormat = new DecimalFormat(formatString, symbols);

## Checklist

- [x] Changes follow the architectural and naming conventions
- [x] Related modules and dependencies are considered
- [ ] Unit tests added/updated where applicable
- [x] Code compiles and passes all tests
- [ ] Public APIs are documented (e.g. Javadoc if needed)

## Notes (optional)
From new learner java and github. :))